### PR TITLE
Skips functions if `window` is not available.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,11 @@ declare global {
 }
 
 /**
+ * Checks current environment is browser based
+ */
+const isBrowser = typeof window !== 'undefined'
+
+/**
  * Enqueues a command to dispatch to fathom when the library is loaded.
  *
  * @param command - A set of arguments to dispatch to fathom later.
@@ -94,7 +99,7 @@ export const load = (siteId: string, opts?: LoadOptions): void => {
  * @param opts - An optional `url` or `referrer` to override auto-detected values.
  */
 export const trackPageview = (opts?: PageViewOptions): void => {
-  if (window.fathom) {
+  if (isBrowser && window.fathom) {
     if (opts) {
       window.fathom.trackPageview(opts);
     } else {
@@ -112,7 +117,7 @@ export const trackPageview = (opts?: PageViewOptions): void => {
  * @param cents - The value in cents.
  */
 export const trackGoal = (code: string, cents: number) => {
-  if (window.fathom) {
+  if (isBrowser && window.fathom) {
     window.fathom.trackGoal(code, cents);
   } else {
     enqueue({ type: 'trackGoal', code, cents });

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,56 +41,62 @@ const isBrowser = typeof window !== 'undefined'
  * @param command - A set of arguments to dispatch to fathom later.
  */
 const enqueue = (command: FathomCommand): void => {
-  window.__fathomClientQueue = window.__fathomClientQueue || [];
-  window.__fathomClientQueue.push(command);
+  if (isBrowser) {
+    window.__fathomClientQueue = window.__fathomClientQueue || [];
+    window.__fathomClientQueue.push(command);
+  }
 };
 
 /**
  * Flushes the command queue.
  */
 const flushQueue = (): void => {
-  window.__fathomClientQueue = window.__fathomClientQueue || [];
-  window.__fathomClientQueue.forEach(command => {
-    switch (command.type) {
-      case 'trackPageview':
-        if (command.opts) {
-          window.fathom.trackPageview(command.opts);
-        } else {
-          window.fathom.trackPageview();
-        }
-        return;
+  if (isBrowser) {
+    window.__fathomClientQueue = window.__fathomClientQueue || [];
+    window.__fathomClientQueue.forEach(command => {
+      switch (command.type) {
+        case 'trackPageview':
+          if (command.opts) {
+            window.fathom.trackPageview(command.opts);
+          } else {
+            window.fathom.trackPageview();
+          }
+          return;
 
-      case 'trackGoal':
-        window.fathom.trackGoal(command.code, command.cents);
-        return;
-    }
-  });
-  window.__fathomClientQueue = [];
+        case 'trackGoal':
+          window.fathom.trackGoal(command.code, command.cents);
+          return;
+      }
+    });
+    window.__fathomClientQueue = [];
+  }
 };
 
 export const load = (siteId: string, opts?: LoadOptions): void => {
-  let tracker = document.createElement('script');
-  let firstScript = document.getElementsByTagName('script')[0];
+  if (isBrowser) {
+    let tracker = document.createElement('script');
+    let firstScript = document.getElementsByTagName('script')[0];
 
-  tracker.id = 'fathom-script';
-  tracker.async = true;
-  tracker.setAttribute('site', siteId);
-  tracker.src =
-    opts && opts.url ? opts.url : 'https://cdn.usefathom.com/script.js';
-  if (opts) {
-    if (opts.auto !== undefined) tracker.setAttribute('auto', `${opts.auto}`);
-    if (opts.honorDNT !== undefined)
-      tracker.setAttribute('honor-dnt', `${opts.honorDNT}`);
-    if (opts.canonical !== undefined)
-      tracker.setAttribute('canonical', `${opts.canonical}`);
-    if (opts.includedDomains)
-      tracker.setAttribute('included-domains', opts.includedDomains.join(','));
-    if (opts.excludedDomains)
-      tracker.setAttribute('excluded-domains', opts.excludedDomains.join(','));
-    if (opts.spa) tracker.setAttribute('spa', opts.spa);
+    tracker.id = 'fathom-script';
+    tracker.async = true;
+    tracker.setAttribute('site', siteId);
+    tracker.src =
+      opts && opts.url ? opts.url : 'https://cdn.usefathom.com/script.js';
+    if (opts) {
+      if (opts.auto !== undefined) tracker.setAttribute('auto', `${opts.auto}`);
+      if (opts.honorDNT !== undefined)
+        tracker.setAttribute('honor-dnt', `${opts.honorDNT}`);
+      if (opts.canonical !== undefined)
+        tracker.setAttribute('canonical', `${opts.canonical}`);
+      if (opts.includedDomains)
+        tracker.setAttribute('included-domains', opts.includedDomains.join(','));
+      if (opts.excludedDomains)
+        tracker.setAttribute('excluded-domains', opts.excludedDomains.join(','));
+      if (opts.spa) tracker.setAttribute('spa', opts.spa);
+    }
+    tracker.onload = flushQueue;
+    firstScript.parentNode.insertBefore(tracker, firstScript);
   }
-  tracker.onload = flushQueue;
-  firstScript.parentNode.insertBefore(tracker, firstScript);
 };
 
 /**


### PR DESCRIPTION
Useful for Static Site Generators (like Gatsby) as `window` is not available during the node build.