### PR TITLE
Warn when including transfer protocol in include/exclude domains

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,25 @@ const flushQueue = (): void => {
   window.__fathomClientQueue = [];
 };
 
+
+/**
+ * Loops through list of domains and warns if they start with
+ * http, https, http://, etc... as this does not work with the
+ * Fathom script.
+ * 
+ * @param domains - List of domains to check
+ */
+const checkDomainsAndWarn = (domains: string[]): void => {
+  const regex = /(https?)(?=:|\/|$)/; // matches http or https followed by
+                                      // either a : or /
+  domains.forEach((domain) => {
+    if (regex.exec(domain) !== null)
+      console.warn('${domain} might fail to work as intended as it begins \
+                    with a transfer protocol (http://, https://), consider \
+                    removing the protocol portion of the string.')
+  });
+}
+
 export const load = (siteId: string, opts?: LoadOptions): void => {
   let tracker = document.createElement('script');
   let firstScript = document.getElementsByTagName('script')[0];

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,9 +76,7 @@ const checkDomainsAndWarn = (domains: string[]): void => {
                                       // either a : or /
   domains.forEach((domain) => {
     if (regex.exec(domain) !== null)
-      console.warn('${domain} might fail to work as intended as it begins \
-                    with a transfer protocol (http://, https://), consider \
-                    removing the protocol portion of the string.')
+      console.warn(`The include domain ${domain} might fail to work as intended as it begins with a transfer protocol (http://, https://), consider removing the protocol portion of the string.`);
   });
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,10 +97,14 @@ export const load = (siteId: string, opts?: LoadOptions): void => {
       tracker.setAttribute('honor-dnt', `${opts.honorDNT}`);
     if (opts.canonical !== undefined)
       tracker.setAttribute('canonical', `${opts.canonical}`);
-    if (opts.includedDomains)
+    if (opts.includedDomains) {
+      checkDomainsAndWarn(opts.includedDomains);
       tracker.setAttribute('included-domains', opts.includedDomains.join(','));
-    if (opts.excludedDomains)
+    }
+    if (opts.excludedDomains) {
+      checkDomainsAndWarn(opts.excludedDomains);
       tracker.setAttribute('excluded-domains', opts.excludedDomains.join(','));
+    }
     if (opts.spa) tracker.setAttribute('spa', opts.spa);
   }
   tracker.onload = flushQueue;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -55,6 +55,24 @@ describe('load', () => {
 
     expect(window.fathom.trackPageview.mock.calls.length).toBe(1);
   });
+
+  it('warns when loading include domains which are not bare domains', () => {
+    window.console = {
+      warn: jest.fn()
+    };
+
+    const firstScript = document.createElement('script');
+    document.body.appendChild(firstScript);
+    Fathom.load('abcde123', {
+      url: 'https://bobheadxi.dev/fathom.js',
+      auto: false,
+      includedDomains: ['https://bobheadxi.dev']
+    });
+
+    expect(window.console.warn).toHaveBeenCalledWith(
+      'The include domain https://bobheadxi.dev might fail to work as intended as it begins with a transfer protocol (http://, https://), consider removing the protocol portion of the string.'
+    );
+  });
 });
 
 describe('trackPageview', () => {


### PR DESCRIPTION
Checks include and exclude domain strings and checks whether any of them start with http://, https:// or some form of the two and console.warn()s if they do.

This may be beyond the scope of what you would like this package to take care of, but when I was using the package I accidentally pasted a complete URL to the includeDomains array, and having this warning would've saved me some time troubleshooting.