### PR TITLE
Add in extra clarity for script.js on custom domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Injects the Fathom script into the DOM and loads the script asynchronously.
 
 - `siteId` - The site ID provided in the Fathom UI.
 - `opts` - An Object of options:
-  - `url` - The URL of the tracking script (defaults to `https://cdn.usefathom.com/script.js`). If you're using [custom domains](https://usefathom.com/support/custom-domains) then you change this parameter.
+  - `url` - The URL of the tracking script (defaults to `https://cdn.usefathom.com/script.js`). If you're using a [custom domain](https://usefathom.com/support/custom-domains) then you should change this parameter to use it (example `https://parrot.yourwebsite.com/script.js`).
   - `auto` - When `false`, skips automatically tracking page views on script load (defaults to `true`).
   - `honorDNT` - When `true`, honors the [DNT header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/DNT) in the visitor's browser
   - `canonical` - When `false`, ignores the canonical tag if present (defaults to `true`).


### PR DESCRIPTION
Small change. This has caught people a few times.