### PR TITLE
fix: use data attributes for options when loading script

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -87,24 +87,24 @@ export const load = (siteId: string, opts?: LoadOptions): void => {
 
   tracker.id = 'fathom-script';
   tracker.async = true;
-  tracker.setAttribute('site', siteId);
+  tracker.setAttribute('data-site', siteId);
   tracker.src =
     opts && opts.url ? opts.url : 'https://cdn.usefathom.com/script.js';
   if (opts) {
-    if (opts.auto !== undefined) tracker.setAttribute('auto', `${opts.auto}`);
+    if (opts.auto !== undefined) tracker.setAttribute('data-auto', `${opts.auto}`);
     if (opts.honorDNT !== undefined)
-      tracker.setAttribute('honor-dnt', `${opts.honorDNT}`);
+      tracker.setAttribute('data-honor-dnt', `${opts.honorDNT}`);
     if (opts.canonical !== undefined)
-      tracker.setAttribute('canonical', `${opts.canonical}`);
+      tracker.setAttribute('data-canonical', `${opts.canonical}`);
     if (opts.includedDomains) {
       checkDomainsAndWarn(opts.includedDomains);
-      tracker.setAttribute('included-domains', opts.includedDomains.join(','));
+      tracker.setAttribute('data-included-domains', opts.includedDomains.join(','));
     }
     if (opts.excludedDomains) {
       checkDomainsAndWarn(opts.excludedDomains);
-      tracker.setAttribute('excluded-domains', opts.excludedDomains.join(','));
+      tracker.setAttribute('data-excluded-domains', opts.excludedDomains.join(','));
     }
-    if (opts.spa) tracker.setAttribute('spa', opts.spa);
+    if (opts.spa) tracker.setAttribute('data-spa', opts.spa);
   }
   tracker.onload = flushQueue;
   firstScript.parentNode.insertBefore(tracker, firstScript);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -32,9 +32,11 @@ describe('load', () => {
 
     const fathomScript = document.getElementById('fathom-script');
     expect(fathomScript.src).toBe('https://bobheadxi.dev/fathom.js');
-    expect(fathomScript.getAttribute('included-domains')).toBe('bobheadxi.dev');
-    expect(fathomScript.getAttribute('auto')).toBe('false');
-    expect(fathomScript.getAttribute('honor-dnt')).toBe(null);
+    expect(fathomScript.getAttribute('data-included-domains')).toBe(
+      'bobheadxi.dev'
+    );
+    expect(fathomScript.getAttribute('data-auto')).toBe('false');
+    expect(fathomScript.getAttribute('data-honor-dnt')).toBe(null);
   });
 
   it('runs the queue after load', () => {


### PR DESCRIPTION
- matches documentation at
  https://usefathom.com/docs/script/script-advanced
- corrects issue with `spa=hash` and tracking - hosted fathom tracker code couples directly to retrieving the value of the `data-spa` attribute on the script tag. The following is a subset of the tracker code (prettified):
```js
trackPageview: function(params) {
    var hostname, pathnameToSend, location = getLocation(params = void 0 === params ? {} : params);
    "" !== location.host && (hostname = location.protocol + "//" + location.hostname, pathnameToSend = location.pathname || "/", "hash" == fathomScript.getAttribute("data-spa") && (pathnameToSend += location.hash), this.send({
        p: pathnameToSend,
        h: hostname,
        r: params.referrer || (document.referrer.indexOf(hostname) < 0 ? document.referrer : ""),
        sid: siteId,
        qs: JSON.stringify(qs())
    }))
},
```