### PR TITLE
fix: Add `blockTrackingForMe` method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,10 @@
 interface Fathom {
+  /**
+   * See https://usefathom.com/docs/features/exclude
+   */
+  blockTrackingForMe?: () => void;
+  enableTrackingForMe?: () => void;
+  
   trackPageview: (opts?: PageViewOptions) => void;
   trackGoal: (code: string, cents: number) => void;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,6 @@
 interface Fathom {
-  /**
-   * See https://usefathom.com/docs/features/exclude
-   */
-  blockTrackingForMe?: () => void;
-  enableTrackingForMe?: () => void;
-  
+  blockTrackingForMe: typeof blockTrackingForMe;
+  enableTrackingForMe: typeof enableTrackingForMe;
   trackPageview: (opts?: PageViewOptions) => void;
   trackGoal: (code: string, cents: number) => void;
 }
@@ -27,7 +23,8 @@ export type LoadOptions = {
 
 type FathomCommand =
   | { type: 'trackPageview'; opts: PageViewOptions | undefined }
-  | { type: 'trackGoal'; code: string; cents: number };
+  | { type: 'trackGoal'; code: string; cents: number }
+  | { type: 'blockTrackingForMe' | 'enableTrackingForMe' };
 
 declare global {
   interface Window {
@@ -63,6 +60,14 @@ const flushQueue = (): void => {
 
       case 'trackGoal':
         window.fathom.trackGoal(command.code, command.cents);
+        return;
+
+      case 'enableTrackingForMe' : 
+        window.fathom.enableTrackingForMe();
+        return;
+        
+      case 'blockTrackingForMe' : 
+        window.fathom.blockTrackingForMe();
         return;
     }
   });
@@ -144,5 +149,25 @@ export const trackGoal = (code: string, cents: number) => {
     window.fathom.trackGoal(code, cents);
   } else {
     enqueue({ type: 'trackGoal', code, cents });
+  }
+};
+
+/**
+ * See https://usefathom.com/docs/features/exclude
+ */
+export const blockTrackingForMe = (): void => {
+  if (window.fathom) {
+    window.fathom.blockTrackingForMe();
+  } else {
+    enqueue({ type: 'blockTrackingForMe' })
+  }
+};
+
+export const enableTrackingForMe = (): void => {
+  if (window.fathom) {
+    window.fathom.enableTrackingForMe();
+  } else {
+    enqueue({ type: 'enableTrackingForMe' })
+
   }
 };


### PR DESCRIPTION
Hi and thanks for this library!

I’m looking at implementing a way to let visitors of my website deactivate tracking entirely, and discovered that the type definition for `Fathom` was incomplete. It lacks the `blockTrackingForMe` and `enableTrackingForMe` methods.

Here’s a proposal to add both of them and queue like the other methods. Note:

- I've kept the type dependent en the functions themselves.
- I have _not_ added tests, but can do.

Information gathered [from the docs](https://usefathom.com/docs/features/exclude) and local testing.