### PR TITLE
Add fallback to load function when no scripts found

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -97,7 +97,7 @@ const checkDomainsAndWarn = (domains: string[]): void => {
 
 export const load = (siteId: string, opts?: LoadOptions): void => {
   let tracker = document.createElement('script');
-  let firstScript = document.getElementsByTagName('script')[0];
+  let firstScript = document.getElementsByTagName('script')[0] || document.querySelector('body');
 
   tracker.id = 'fathom-script';
   tracker.async = true;


### PR DESCRIPTION
`load` fails with a type error if no existing script files are found on the page using the `Fathom.load` function.

I've added a fallback to insert immediately before the `<body>` tag.

(I started seeing errors when using with [SvelteKit v1.0.0-next.257](https://github.com/sveltejs/kit/blob/master/packages/kit/CHANGELOG.md#100-next257) onwards; 257 had some breaking changes relating to how the hydration script works. This patch appears to fix.)