### PR TITLE
Proposal: An api for checking if Fathom has received user request not track.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -97,7 +97,9 @@ const checkDomainsAndWarn = (domains: string[]): void => {
 
 export const load = (siteId: string, opts?: LoadOptions): void => {
   let tracker = document.createElement('script');
-  let firstScript = document.getElementsByTagName('script')[0] || document.querySelector('body');
+  let firstScript =
+    document.getElementsByTagName('script')[0] ||
+    document.querySelector('body');
 
   tracker.id = 'fathom-script';
   tracker.async = true;
@@ -186,6 +188,14 @@ export const enableTrackingForMe = (): void => {
   } else {
     enqueue({ type: 'enableTrackingForMe' });
   }
+};
+
+/**
+ * Checks if tracking is enabled for the current vistior
+ */
+export const isTrackingEnabled = (): boolean => {
+  const preferenceStorage: string = localStorage.getItem('blockFathomTracking');
+  return preferenceStorage !== null ? preferenceStorage !== 'true' : true;
 };
 
 /**


### PR DESCRIPTION
`enableTrackingForMe()` and `blockTrackingForMe()` are great for letting users customize their privacy settings. This small addition will read the `localStorage` object that Fathom uses to determine whether to track/not to track the user and return the result using the same API as the rest of the lib.

I found this to be a requirement when I was making my UI (it needs to know if Fathom is tracking on component mount):

![Screen Shot 2022-06-14 at 6 31 23 PM](https://user-images.githubusercontent.com/8587882/173717441-e9778964-1216-4d85-ae4b-6c5ff01d9335.png)

If this looks good, I'll add a test as well (this will most likely call for a localStorage mocking package -- lmk if that's OK also).

Thanks!