### PR TITLE
Adds support for trackEvent

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ interface Fathom {
   enableTrackingForMe: () => void;
   trackPageview: (opts?: PageViewOptions) => void;
   trackGoal: (code: string, cents: number) => void;
+  trackEvent: (code: string, opts?: EventOptions) => void;
   setSite: (id: string) => void;
 }
 
@@ -10,6 +11,11 @@ export type PageViewOptions = {
   url?: string;
   referrer?: string;
 };
+
+export type EventOptions = {
+  _value?: number,
+  _site_id?: string
+}
 
 // refer to https://usefathom.com/support/tracking-advanced
 export type LoadOptions = {
@@ -25,6 +31,7 @@ export type LoadOptions = {
 type FathomCommand =
   | { type: 'trackPageview'; opts: PageViewOptions | undefined }
   | { type: 'trackGoal'; code: string; cents: number }
+  | { type: 'trackEvent'; event_name: string; opts: EventOptions | undefined }
   | { type: 'blockTrackingForMe' }
   | { type: 'enableTrackingForMe' }
   | { type: 'setSite'; id: string };
@@ -59,6 +66,10 @@ const flushQueue = (): void => {
 
       case 'trackGoal':
         trackGoal(command.code, command.cents);
+        return;
+
+      case 'trackEvent':
+        trackEvent(command.event_name, command.opts);
         return;
 
       case 'enableTrackingForMe':
@@ -155,12 +166,30 @@ export const trackPageview = (opts?: PageViewOptions): void => {
  *
  * @param code - The goal ID.
  * @param cents - The value in cents.
+ * @deprecated If you are using this to track an existing goal, however, it will continue to work.
+ * @see https://usefathom.com/docs/features/events
  */
 export const trackGoal = (code: string, cents: number) => {
   if (window.fathom) {
     window.fathom.trackGoal(code, cents);
   } else {
     enqueue({ type: 'trackGoal', code, cents });
+  }
+};
+
+/**
+ * Tracks a dynamic event.
+ *
+ * @param event_name - This can be nearly anything you want. Avoid special chars and emojis
+ * @param _value - The value in cents.
+ * @param _site_id - The value in cents.
+ * @see https://usefathom.com/docs/features/events
+ */
+export const trackEvent = (event_name: string, opts?: EventOptions) => {
+  if (window.fathom) {
+    window.fathom.trackEvent(event_name, opts);
+  } else {
+    enqueue({ type: 'trackEvent', event_name, opts });
   }
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ interface Fathom {
   enableTrackingForMe: () => void;
   trackPageview: (opts?: PageViewOptions) => void;
   trackGoal: (code: string, cents: number) => void;
-  trackEvent: (code: string, opts?: EventOptions) => void;
+  trackEvent: (event_name: string, opts?: EventOptions) => void;
   setSite: (id: string) => void;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ interface Fathom {
   enableTrackingForMe: () => void;
   trackPageview: (opts?: PageViewOptions) => void;
   trackGoal: (code: string, cents: number) => void;
-  trackEvent: (event_name: string, opts?: EventOptions) => void;
+  trackEvent: (eventName: string, opts?: EventOptions) => void;
   setSite: (id: string) => void;
 }
 
@@ -13,9 +13,9 @@ export type PageViewOptions = {
 };
 
 export type EventOptions = {
-  _value?: number,
-  _site_id?: string
-}
+  _value?: number;
+  _site_id?: string;
+};
 
 // refer to https://usefathom.com/support/tracking-advanced
 export type LoadOptions = {
@@ -31,7 +31,7 @@ export type LoadOptions = {
 type FathomCommand =
   | { type: 'trackPageview'; opts: PageViewOptions | undefined }
   | { type: 'trackGoal'; code: string; cents: number }
-  | { type: 'trackEvent'; event_name: string; opts: EventOptions | undefined }
+  | { type: 'trackEvent'; eventName: string; opts: EventOptions | undefined }
   | { type: 'blockTrackingForMe' }
   | { type: 'enableTrackingForMe' }
   | { type: 'setSite'; id: string };
@@ -69,7 +69,7 @@ const flushQueue = (): void => {
         return;
 
       case 'trackEvent':
-        trackEvent(command.event_name, command.opts);
+        trackEvent(command.eventName, command.opts);
         return;
 
       case 'enableTrackingForMe':
@@ -180,16 +180,17 @@ export const trackGoal = (code: string, cents: number) => {
 /**
  * Tracks a dynamic event.
  *
- * @param event_name - This can be nearly anything you want. Avoid special chars and emojis
- * @param _value - The value in cents.
- * @param _site_id - The value in cents.
+ * @param eventName - This can be nearly anything you want. Avoid special chars and emojis.
+ * @param opts - A collection of options.
+ * @param opts._site_id - The site ID (optional).
+ * @param opts._value - The value in cents (optional).
  * @see https://usefathom.com/docs/features/events
  */
-export const trackEvent = (event_name: string, opts?: EventOptions) => {
+export const trackEvent = (eventName: string, opts?: EventOptions) => {
   if (window.fathom) {
-    window.fathom.trackEvent(event_name, opts);
+    window.fathom.trackEvent(eventName, opts);
   } else {
-    enqueue({ type: 'trackEvent', event_name, opts });
+    enqueue({ type: 'trackEvent', eventName, opts });
   }
 };
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -148,7 +148,11 @@ describe('trackEvent', () => {
   it('enqueues the operation if fathom is not loaded', () => {
     Fathom.trackEvent('dynamic event test', { _value: 0 });
     expect(window.__fathomClientQueue).toStrictEqual([
-      { type: 'trackEvent', event_name: 'dynamic event test', opts: { _value: 0 } }
+      {
+        type: 'trackEvent',
+        eventName: 'dynamic event test',
+        opts: { _value: 0 }
+      }
     ]);
   });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -48,7 +48,8 @@ describe('load', () => {
 
     window.fathom = {
       trackPageview: jest.fn(),
-      trackGoal: jest.fn()
+      trackGoal: jest.fn(),
+      trackEvent: jest.fn()
     };
 
     const firstScript = document.createElement('script');
@@ -96,7 +97,8 @@ describe('trackPageview', () => {
           expect(args).toStrictEqual([]);
           resolve();
         },
-        trackGoal: jest.fn()
+        trackGoal: jest.fn(),
+        trackEvent: jest.fn()
       };
 
       Fathom.trackPageview();
@@ -110,7 +112,8 @@ describe('trackPageview', () => {
           expect(args).toStrictEqual([{ url: 'https://bobheadxi.dev' }]);
           resolve();
         },
-        trackGoal: jest.fn()
+        trackGoal: jest.fn(),
+        trackEvent: jest.fn()
       };
 
       Fathom.trackPageview({ url: 'https://bobheadxi.dev' });
@@ -137,6 +140,31 @@ describe('trackGoal', () => {
       };
 
       Fathom.trackGoal('Sign Up', 0);
+    });
+  });
+});
+
+describe('trackEvent', () => {
+  it('enqueues the operation if fathom is not loaded', () => {
+    Fathom.trackEvent('dynamic event test', { _value: 0 });
+    expect(window.__fathomClientQueue).toStrictEqual([
+      { type: 'trackEvent', event_name: 'dynamic event test', opts: { _value: 0 } }
+    ]);
+  });
+
+  it('calls the fathom function if loaded', () => {
+    return new Promise(resolve => {
+      window.fathom = {
+        trackPageview: jest.fn(),
+        trackEvent: (...args) => {
+          expect(args).toStrictEqual(['dynamic event test', { _value: 0 }]);
+          resolve();
+        }
+      };
+
+      Fathom.trackEvent('dynamic event test', {
+        _value: 0
+      });
     });
   });
 });


### PR DESCRIPTION
Adds support for the new `trackEvent` function. Marks `trackGoal` as deprecated

https://usefathom.com/docs/features/events