### PR TITLE
Avoid `Type error: 'searchParams' is possibly 'null'.` in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       <head></head>
       <body>
         <Fathom />
-        <Page>{children}</Page>
+        {children}
       </body>
     </html>
   );

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ function TrackPageView() {
     if (!pathname) return;
 
     trackPageview({
-      url: pathname + searchParams.toString(),
+      url: pathname + searchParams?.toString(),
       referrer: document.referrer
     });
   }, [pathname, searchParams]);


### PR DESCRIPTION
Out of the box (on next@14), the app router example code fails to build with a Type error, since `searchParams` can be `null`:

```
./app/Fathom.tsx:25:23
Type error: 'searchParams' is possibly 'null'.
  23 |
  24 |     trackPageview({
> 25 |       url: pathname + searchParams.toString(),
     |                       ^
  26 |       referrer: document.referrer
  27 |     });
  28 |   }, [pathname, searchParams]);
Error: Command "npm run vercel-build" exited with 1
```

This allows for that with the optional chaining `?.` operator.
